### PR TITLE
Fix association not found error

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_configurable_kits.js
+++ b/app/assets/javascripts/spree/frontend/solidus_configurable_kits.js
@@ -4,6 +4,7 @@ Spree.ready(function($) {
   Spree.updateKitPrice = function() {
     var selectedVariant = $("input[name='variant_id']:checked")[0]
     var hiddenVariantField = $("input[name='variant_id']")[0]
+    var priceCurrency = $("[itemprop='priceCurrency']");
 
     if (!(selectedVariant || hiddenVariantField)) { return }
 
@@ -30,7 +31,7 @@ Spree.ready(function($) {
     if (variantPrice) {
       var formatter = new Intl.NumberFormat('en-US', {
         style: 'currency',
-        currency: 'EUR',
+        currency: priceCurrency.attr('content'),
       });
 
       $(".price.selling").text(formatter.format(sum));

--- a/app/decorators/controllers/solidus_configurable_kits/spree/api/variants_controller_decorator.rb
+++ b/app/decorators/controllers/solidus_configurable_kits/spree/api/variants_controller_decorator.rb
@@ -10,7 +10,7 @@ module SolidusConfigurableKits
           [
             { option_values: :option_type },
             { product: :kit_requirements },
-            :default_price,
+#             :default_price,
             :images,
             { stock_items: :stock_location },
           ]


### PR DESCRIPTION
Attempting to retrieve variants via the API produces a server error
due to ActiveRecord::AssociationNotFoundError on :default_price