### PR TITLE
Fix association not found error

### DIFF
--- a/app/decorators/controllers/solidus_configurable_kits/spree/api/variants_controller_decorator.rb
+++ b/app/decorators/controllers/solidus_configurable_kits/spree/api/variants_controller_decorator.rb
@@ -10,7 +10,7 @@ module SolidusConfigurableKits
           [
             { option_values: :option_type },
             { product: :kit_requirements },
-            :default_price,
+#             :default_price,
             :images,
             { stock_items: :stock_location },
           ]

--- a/app/decorators/controllers/solidus_configurable_kits/spree/api/variants_controller_decorator.rb
+++ b/app/decorators/controllers/solidus_configurable_kits/spree/api/variants_controller_decorator.rb
@@ -14,7 +14,7 @@ module SolidusConfigurableKits
             :images,
             { stock_items: :stock_location },
           ]
-          list.push(:default_price) if Spree.solidus_gem_version <= Gem::Version.new('3')
+          list.push(:default_price) if Spree.solidus_gem_version < Gem::Version.new('3')
           list
         end
 

--- a/app/decorators/controllers/solidus_configurable_kits/spree/api/variants_controller_decorator.rb
+++ b/app/decorators/controllers/solidus_configurable_kits/spree/api/variants_controller_decorator.rb
@@ -7,13 +7,15 @@ module SolidusConfigurableKits
         private
 
         def include_list
-          [
+          list = [
             { option_values: :option_type },
             { product: :kit_requirements },
 #             :default_price,
             :images,
             { stock_items: :stock_location },
           ]
+          list.push(:default_price) if Spree.solidus_gem_version <= Gem::Version.new('3')
+          list
         end
 
         ::Spree::Api::VariantsController.prepend self


### PR DESCRIPTION
Attempting to retrieve a variant via the API produces an ActiveRecord::AssociationNotFoundError
due to ActiveRecord::AssociationNotFoundError on :default_price in Solidus 3