### PR TITLE
Fix no method error due to namespacing

### DIFF
--- a/app/decorators/controllers/solidus_configurable_kits/spree/api/variants_controller_decorator.rb
+++ b/app/decorators/controllers/solidus_configurable_kits/spree/api/variants_controller_decorator.rb
@@ -14,7 +14,7 @@ module SolidusConfigurableKits
             :images,
             { stock_items: :stock_location },
           ]
-          list.push(:default_price) if Spree.solidus_gem_version < Gem::Version.new('3')
+          list.push(:default_price) if ::Spree.solidus_gem_version < Gem::Version.new('3')
           list
         end
 


### PR DESCRIPTION
`Spree.solidus_gem_version` should be `::Spree.solidus_gem_version` or else rails assumes the wrong namespace for Spree and throws an error `NoMethodError (undefined method 'solidus_gem_version' for SolidusConfigurableKits::Spree:Module)`