### PR TITLE
shipping_manifest: don't crash if there are no items

### DIFF
--- a/app/models/solidus_configurable_kits/shipping_manifest.rb
+++ b/app/models/solidus_configurable_kits/shipping_manifest.rb
@@ -10,7 +10,9 @@ module SolidusConfigurableKits
         result += [grouped_by_kit[nil].detect{ |i| i.line_item = kit_line_item }]
         result += grouped_by_kit[kit_line_item]
       end
-      result += grouped_by_kit[nil].reject { |manifest_item| manifest_item.line_item.kit? }
+      unless grouped_by_kit[nil].nil?
+        result += grouped_by_kit[nil].reject { |manifest_item| manifest_item.line_item.kit? }
+      end
     end
   end
 end


### PR DESCRIPTION
We tripped over this line crashing when removing a kit from someones cart in the admin (to change their order by request).