### PR TITLE
Fix order merger issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ bin/rails generate solidus_configurable_kits:install
 
 First, make sure that your `Spree::Config.variant_price_selector_class` is either the `SolidusConfigurableKits::PriceSelector` or a class that inherits from it / offers the same functionality.
 
+Also, make sure that your `Spree:Config.order_merger_class` is either the `SolidusConfigurableKits::OrderMerger` or a class that inherits from it/ offers the same functionality.
+
 You can then mark some variants as eligible to be included in kits by adding a "Kit Price" to them. The Kit price will be added to the price of the base kit variant, and will in many cases by `0`.
 
 Afterwards, create your Kit product, and add some kit requirements on the "Kits" tab. On the product display page and in the admin cart, you will now be prompted for the variants that have kit prices before being able to add that product to the cart, and the cart will include some line items that result from fulfilling the kit requirements.

--- a/app/decorators/models/solidus_configurable_kits/spree/line_item_decorator.rb
+++ b/app/decorators/models/solidus_configurable_kits/spree/line_item_decorator.rb
@@ -18,12 +18,13 @@ module SolidusConfigurableKits
           class_name: "::SolidusConfigurableKits::Requirement",
           foreign_key: :requirement_id,
           optional: true
+
         base.before_validation :update_prices_after_variant_change
         base.before_validation :update_kit_item_quantities
         base.before_validation :create_kit_items
         base.money_methods :kit_total
         base.validate :all_required_kit_items_present
-        base.attribute :kit_variant_ids, default: []
+        base.attribute :kit_variant_ids, default: {}
       end
 
       def kit_item?

--- a/app/decorators/models/solidus_configurable_kits/spree/line_item_decorator.rb
+++ b/app/decorators/models/solidus_configurable_kits/spree/line_item_decorator.rb
@@ -42,6 +42,7 @@ module SolidusConfigurableKits
 
       def update_prices_after_variant_change
         return unless variant_id_changed?
+        return unless variant
         self.price = nil
         set_pricing_attributes
       end

--- a/app/decorators/models/solidus_configurable_kits/spree/order_decorator.rb
+++ b/app/decorators/models/solidus_configurable_kits/spree/order_decorator.rb
@@ -4,13 +4,19 @@ module SolidusConfigurableKits
   module Spree
     module OrderDecorator
       def self.prepended(base)
-        base.register_line_item_comparison_hook :never_match_kit_items
+        base.register_line_item_comparison_hook :matching_kit_variant_ids
       end
 
       private
 
-      def never_match_kit_items(line_item, _options)
-        !(line_item.kit_item? || line_item.kit_items.present?)
+      def matching_kit_variant_ids(line_item, options)
+        return false if line_item.kit_item?
+        existing_kit_variant_ids = line_item.kit_items.map do |kit_item|
+          [kit_item.kit_requirement.id.to_s, kit_item.variant_id.to_s]
+        end.to_h
+        wanted_kit_variant_ids = (options["kit_variant_ids"] || {})
+
+        existing_kit_variant_ids == wanted_kit_variant_ids
       end
 
       ::Spree::Order.prepend self

--- a/app/models/solidus_configurable_kits/order_merger.rb
+++ b/app/models/solidus_configurable_kits/order_merger.rb
@@ -27,7 +27,7 @@ module SolidusConfigurableKits
     # @return [void]
     def merge!(other_order, user = nil)
       if other_order.currency == order.currency
-        other_order.line_items.each do |other_order_line_item|
+        other_order.line_items.reject(&:kit_item?).each do |other_order_line_item|
           current_line_item = find_matching_line_item(other_order_line_item)
           handle_merge(current_line_item, other_order_line_item)
         end

--- a/app/models/solidus_configurable_kits/order_merger.rb
+++ b/app/models/solidus_configurable_kits/order_merger.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module SolidusConfigurableKits
+  class OrderMerger < ::Spree::OrderMerger
+    # Merge a second order in to the order the OrderMerger was initialized with
+    #
+    # The line items from `other_order` will be merged in to the `order` for
+    # this OrderMerger object. If the line items are for the same variant, it
+    # will add the quantity of the incoming line item to the existing line item.
+    # Otherwise, it will assign the line item to the new order.
+    #
+    # After the orders have been merged the `other_order` will be destroyed.
+    #
+    # @example
+    #   initial_order = Spree::Order.find(1)
+    #   order_to_merge = Spree::Order.find(2)
+    #   merger = Spree::OrderMerger.new(initial_order)
+    #   merger.merge!(order_to_merge)
+    #   # order_to_merge is destroyed, initial order now contains the line items
+    #   # of order_to_merge
+    #
+    # @api public
+    # @param [Spree::Order] other_order An order which will be merged in to the
+    # order the OrderMerger was initialized with.
+    # @param [Spree::User] user Associate the order the user specified. If not
+    # specified, the order user association will not be changed.
+    # @return [void]
+    def merge!(other_order, user = nil)
+      if other_order.currency == order.currency
+        other_order.line_items.each do |other_order_line_item|
+          current_line_item = find_matching_line_item(other_order_line_item)
+          handle_merge(current_line_item, other_order_line_item)
+        end
+      end
+
+      set_user(user)
+      if order.valid?
+        persist_merge
+
+        # So that the destroy doesn't take out line items which may have been re-assigned
+        other_order.line_items.reload
+        other_order.destroy
+      end
+    end
+  end
+end

--- a/lib/solidus_configurable_kits/engine.rb
+++ b/lib/solidus_configurable_kits/engine.rb
@@ -15,6 +15,13 @@ module SolidusConfigurableKits
       ::Spree::PermittedAttributes.line_item_attributes << { kit_variant_ids: {} }
     end
 
+    initializer 'solidus_configurable_kits.set_default_classes' do
+      Spree.config do |config|
+        config.variant_price_selector_class = "SolidusConfigurableKits::PriceSelector"
+        config.order_merger_class = "SolidusConfigurableKits::OrderMerger"
+      end
+    end
+
     class << self
       def activate
         ActionView::Base.include SolidusConfigurableKits::KitPricingHelper

--- a/spec/models/solidus_configurable_kits/order_merger_spec.rb
+++ b/spec/models/solidus_configurable_kits/order_merger_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusConfigurableKits::OrderMerger, type: :model do
+  let(:variant) { create(:variant) }
+  let!(:store) { create(:store, default: true) }
+  let(:order_1) { Spree::Order.create }
+  let(:order_2) { Spree::Order.create }
+  let(:user) { create(:user, email: "solidus@example.com") }
+  let(:subject) { Spree::OrderMerger.new(order_1) }
+
+  it "destroys the other order" do
+    subject.merge!(order_2)
+    expect { order_2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it "persist the merge" do
+    expect(subject).to receive(:persist_merge)
+    subject.merge!(order_2)
+  end
+
+  context "user is provided" do
+    it "assigns user to new order" do
+      subject.merge!(order_2, user)
+      expect(order_1.user).to eq user
+    end
+  end
+
+  context "merging together two orders with line items for the same variant" do
+    before do
+      order_1.contents.add(variant, 1)
+      order_2.contents.add(variant, 1)
+    end
+
+    specify do
+      subject.merge!(order_2, user)
+      expect(order_1.line_items.count).to eq(1)
+
+      line_item = order_1.line_items.first
+      expect(line_item.quantity).to eq(2)
+      expect(line_item.variant_id).to eq(variant.id)
+    end
+  end
+
+  context 'merging together two orders with multiple currencies line items' do
+    let(:order_2) { Spree::Order.create(currency: 'JPY') }
+    let(:variant_2) { create(:variant) }
+
+    before do
+      Spree::Price.create(variant: variant_2, amount: 10, currency: 'JPY')
+      order_1.contents.add(variant, 1)
+      order_2.contents.add(variant_2.reload, 1)
+    end
+
+    it 'rejects other order line items' do
+      subject.merge!(order_2, user)
+      expect(order_1.line_items.count).to eq(1)
+
+      line_item = order_1.line_items.first
+      expect(line_item.quantity).to eq(1)
+      expect(line_item.variant_id).to eq(variant.id)
+    end
+  end
+
+  context "merging using extension-specific line_item_comparison_hooks" do
+    before do
+      Spree::Order.register_line_item_comparison_hook(:foos_match)
+    end
+
+    after do
+      # reset to avoid test pollution
+      Spree::Order.line_item_comparison_hooks = Set.new
+    end
+
+    context "2 equal line items" do
+      before do
+        @line_item_one = order_1.contents.add(variant, 1, foos: {})
+        @line_item_two = order_2.contents.add(variant, 1, foos: {})
+      end
+
+      specify do
+        without_partial_double_verification do
+          expect(order_1).to receive(:foos_match).with(@line_item_one, kind_of(Hash)).and_return(true)
+        end
+        subject.merge!(order_2)
+        expect(order_1.line_items.count).to eq(1)
+
+        line_item = order_1.line_items.first
+        expect(line_item.quantity).to eq(2)
+        expect(line_item.variant_id).to eq(variant.id)
+      end
+    end
+
+    context "2 different line items" do
+      before do
+        without_partial_double_verification do
+          allow(order_1).to receive(:foos_match).and_return(false)
+        end
+
+        order_1.contents.add(variant, 1, foos: {})
+        order_2.contents.add(variant, 1, foos: { bar: :zoo })
+      end
+
+      specify do
+        subject.merge!(order_2)
+        expect(order_1.line_items.count).to eq(2)
+
+        line_item = order_1.line_items.first
+        expect(line_item.quantity).to eq(1)
+        expect(line_item.variant_id).to eq(variant.id)
+
+        line_item = order_1.line_items.last
+        expect(line_item.quantity).to eq(1)
+        expect(line_item.variant_id).to eq(variant.id)
+      end
+    end
+  end
+
+  context "merging together two orders with different line items" do
+    let(:variant_2) { create(:variant) }
+
+    before do
+      order_1.contents.add(variant, 1)
+      order_2.contents.add(variant_2, 1)
+    end
+
+    specify do
+      subject.merge!(order_2)
+
+      # Both in memory and in DB line items
+      expect(order_1.line_items.length).to eq(2)
+      expect(order_1.line_items.count).to eq(2)
+
+      expect(order_1.item_count).to eq 2
+      expect(order_1.item_total).to eq order_1.line_items.sum(&:amount)
+
+      # No guarantee on ordering of line items, so we do this:
+      expect(order_1.line_items.pluck(:quantity)).to match_array([1, 1])
+      expect(order_1.line_items.pluck(:variant_id)).to match_array([variant.id, variant_2.id])
+    end
+
+    context "with line item promotion applied to order 2" do
+      let!(:promotion) { create(:promotion, :with_line_item_adjustment, apply_automatically: true) }
+
+      before do
+        Spree::PromotionHandler::Cart.new(order_2).activate
+        expect(order_2.line_items.flat_map(&:adjustments)).not_to be_empty
+      end
+
+      it "does not carry a line item adjustments with the wrong order ID over" do
+        subject.merge!(order_2)
+        expect(order_1.line_items.flat_map(&:adjustments)).to be_empty
+      end
+    end
+  end
+
+  context "merging together orders with invalid line items" do
+    before do
+      order_1.contents.add(create(:variant), 1)
+      order_2.contents.add(create(:variant), 1)
+    end
+
+    it "should create errors with invalid line items" do
+      order_2.line_items.first.variant.destroy
+      order_2.line_items.reload # so that it registers as invalid
+      subject.merge!(order_2)
+      expect(order_1.errors.full_messages).not_to be_empty
+    end
+  end
+end


### PR DESCRIPTION
This introduces a new `SolidusConfigurableKits::OrderMerger` class and sets that as the default `Spree.config.order_merger_class`. It does not try to duplicate kit item line items (as those are dependent on existing kit line items). 

We also fix the `Spree::Order.line_item_comparison_hooks` to identify actually identical kits (with the same options chosen) as the same, while identifying kits with different options as different items. 

Fixes #8 
